### PR TITLE
Feature: Fetch sign up, log in api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
     "jsx-a11y/label-has-associated-control": "off",
     "react/self-closing-comp": "off",
     "dot-notation": 0,
-    "quotes": ["error", "single"]
+    "quotes": ["error", "single"],
+    "react/require-default-props": "off"
   }
 }

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -5,10 +5,10 @@ import React from 'react'
 
 export default function LinkButton({
   children,
-  href,
-  onClick,
-  style,
-  disabled,
+  href = undefined,
+  onClick = undefined,
+  style = undefined,
+  disabled = undefined,
 }: {
   children: React.ReactNode
   href?: string
@@ -36,11 +36,4 @@ export default function LinkButton({
       {children}
     </Button>
   )
-}
-
-LinkButton.defaultProps = {
-  href: undefined,
-  onClick: undefined,
-  style: undefined,
-  disabled: false,
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -24,7 +24,7 @@ export default function Login() {
     } else {
       setIsLogged(false)
     }
-  })
+  }, [router])
 
   const handleOnClick = async () => {
     try {

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -16,7 +16,7 @@ export default function SignUp() {
     } else {
       setIsLogged(false)
     }
-  })
+  }, [router])
 
   const [failed, setFailed] = useState(false)
 


### PR DESCRIPTION
demo:

https://github.com/yumin-jung/carillon-frontend/assets/86871951/bb248d76-a4d1-4d36-94d2-1270877d3f18

- Sign up과 log in에서 API fetch 구현했습니다
- [여기서](https://github.com/yumin-jung/carillon-frontend/pull/14) 말한 대로 로그인 시 발급받는 token을 localStorage에 저장했습니다.
- 로그인한 상태에서는 log in 페이지와 sign up 페이지 접속 시 workspace 페이지로 이동하게 하였습니다.
- Password validation을 SRS에 맞게 수정하고 허용하는 특수문자를 한정하였습니다.
- 로그인 후 자동으로 이동하는 페이지를 수정해야 할 수도 있습니다. (현재는 `/workspace`)